### PR TITLE
For cabal install to work with ghc 7.0.4

### DIFF
--- a/HaRe.cabal
+++ b/HaRe.cabal
@@ -25,13 +25,13 @@ Executable hare-evaluate
 Executable hare
         Main-Is:                refactorer/pfe.hs
         GHC-Options:            -itools/base/parse2/LexerSpec/:tools/base/parse2/LexerGen:tools/base/lib:tools/base/parse2/Lexer/:tools/base/tests/HbcLibraries:refactorer/:StrategyLib-4.0-beta/library/:StrategyLib-4.0-beta/src:StrategyLib-4.0-beta/models/deriving/:tools/base/parse2:tools/base/AST:tools/base/Modules:tools/base/pretty/:tools/base/defs/:tools/base/:tools/base/lib/Monads/:tools/base/parse2/Parser/:tools/base/syntax:tools/base/TI:tools/pfe:tools/base/transforms:tools/base/transforms/Deriving:tools/hs2html/ -fno-cse -fglasgow-exts  
-        Build-Depends:          base >=4 && <= 4.2.0.2, syb, network, ghc, haskell98, containers, hint, mtl, directory, pretty, process, filepath
+        Build-Depends:          base >=4, syb, network, ghc, haskell98, containers, hint, mtl, directory, pretty, process, filepath
         Extensions:             CPP, MultiParamTypeClasses, OverlappingInstances, UndecidableInstances, FunctionalDependencies, NoMonomorphismRestriction
         Other-Modules:          Paths_HaRe
 
 Executable hare-client
         Main-Is:                refactorer/pfe_client.hs
         GHC-Options:            -itools/base/parse2/LexerSpec/:tools/base/parse2/LexerGen:tools/base/lib:tools/base/parse2/Lexer/:tools/base/tests/HbcLibraries:refactorer/:StrategyLib-4.0-beta/library/:StrategyLib-4.0-beta/src:StrategyLib-4.0-beta/models/deriving/:tools/base/parse2:tools/base/AST:tools/base/Modules:tools/base/pretty/:tools/base/defs/:tools/base/:tools/base/lib/Monads/:tools/base/parse2/Parser/:tools/base/syntax:tools/base/TI:tools/pfe:tools/base/transforms:tools/base/transforms/Deriving:tools/hs2html/ -fno-cse -fglasgow-exts  
-        Build-Depends:          base >=4 && <= 4.2.0.2, syb, network, ghc, haskell98, containers, hint, mtl, directory, pretty, process, filepath
+        Build-Depends:          base >=4, syb, network, ghc, haskell98, containers, hint, mtl, directory, pretty, process, filepath
         Extensions:             CPP, MultiParamTypeClasses, OverlappingInstances, UndecidableInstances, FunctionalDependencies, NoMonomorphismRestriction
         Other-Modules:          Paths_HaRe

--- a/refactorer/RefacUtils.hs
+++ b/refactorer/RefacUtils.hs
@@ -136,7 +136,7 @@ import LocalSettings
 import StrategyLib hiding (findFile, fail, (>>=), (>>), return, mfix, Monad, Functor, MonadFix, MonadPlus, fmap, (=<<),
                            sequence_, sequence, mapM_, mapM, liftM5, liftM4, liftM3, mzero, mplus, guard, filterM, msum,
                            join, mapAndUnzipM, zipWithM, zipWithM_, foldM, when, unless, liftM, liftM2, ap, MonadTrans, MonadIO,
-                           fix, lift, liftIO, StateT, runStateT, State, runState )
+                           fix, lift, liftIO, StateT, runStateT, State )
 import Control.Monad.State
 import TypeCheck
 

--- a/tools/base/defs/UniqueNames.hs
+++ b/tools/base/defs/UniqueNames.hs
@@ -7,7 +7,7 @@ import HasBaseName
 --import NoEq
 import qualified SrcLoc1 as L
 import Maybe(fromMaybe)
-import Data.Generics
+import Data.Generics hiding (empty)
 
 -- Types to decorate identifiers to make them unique
 


### PR DESCRIPTION
Removed restriction on base version, removed hiding of runState in RefacUtils and eliminated ambigious empty in UniqueNames
